### PR TITLE
Fix support for namespace handlers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/src/finder.js
+++ b/src/finder.js
@@ -63,13 +63,15 @@ export function find (node, args, raw, minimist) {
   }
 
   // Prioritize first arg as command name
-  const command = validateCommand(isCommand(next) || isCommand(node), tail)
+  const nextIsCommand = isCommand(next)
+  const passedArgs = nextIsCommand ? tail : args
+  const command = validateCommand(nextIsCommand || isCommand(node), passedArgs)
   const argv = minimist(raw, optionsByType(findOptions(command || node)))
 
   return {
     command,
     node: node,
-    args: tail.slice(0, getArgsNumber(command)).concat(argv),
+    args: passedArgs.slice(0, getArgsNumber(command)).concat(argv),
   }
 }
 

--- a/src/finder.test.js
+++ b/src/finder.test.js
@@ -87,6 +87,26 @@ const cases = [
       a: 'test',
     }],
   },
+  {
+    argv: ['settings', 'cool-app'],
+    command: tree.settings,
+    args: ['cool-app', {}],
+  },
+  {
+    argv: ['settings', 'cool-app', 'someField'],
+    command: tree.settings,
+    args: ['cool-app', 'someField', {}],
+  },
+  {
+    argv: ['settings', 'set', 'cool-app', 'someField', 'abc123'],
+    command: tree.settings.set,
+    args: ['cool-app', 'someField', 'abc123', {}],
+  },
+  {
+    argv: ['settings', 'unset', 'cool-app', 'someField'],
+    command: tree.settings.unset,
+    args: ['cool-app', 'someField', {}],
+  },
 ]
 
 cases.forEach((c) => {

--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -98,4 +98,21 @@ export const tree = {
       handler: console.log.bind(console),
     },
   },
+  settings: {
+    requiredArgs: 'app',
+    optionalArgs: 'field',
+    description: 'Get an app\'s settings',
+    handler: console.log.bind(console),
+
+    set: {
+      requiredArgs: ['app', 'field', 'value'],
+      description: 'Set an app\'s settings value',
+      handler: console.log.bind(console),
+    },
+    unset: {
+      requiredArgs: ['app', 'field'],
+      description: 'Unset an app\'s settings value',
+      handler: console.log.bind(console),
+    },
+  },
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -5,7 +5,7 @@ import pad from 'pad'
 export function help (tree, pkg) {
   const rootOptions = filter(isOptions)(tree)
   const namespaces = {
-    root: filter(isCommand)(tree),
+    root: filter(node => isCommand(node) && !isNamespace(node))(tree),
     ...filter(isNamespace)(tree),
   }
 
@@ -49,7 +49,14 @@ function addNamespace (namespace) {
 
 function formatNamespace (node, namespace) {
   const ns = namespace === 'root' ? undefined : namespace
-  const namespaced = map(addNamespace(ns), node)
+  const commands = filter(isCommand)(node)
+
+  let namespaced = {}
+  if (isCommand(node)) {
+    namespaced[namespace] = node
+  }
+  namespaced = {...namespaced, ...map(addNamespace(ns), commands)}
+
   const maxLength = Math.max(...values(map(pipe(formatCommandArgs, length), namespaced)))
   return values(mapObjIndexed(formatCommand(maxLength), namespaced)).join('\n')
 }

--- a/src/helper.test.js
+++ b/src/helper.test.js
@@ -1,0 +1,7 @@
+import test from 'ava'
+import {tree} from './fixtures'
+import {help} from './helper'
+
+test('help', () => {
+  help(tree, {name: 'findhelp', version: '0.0.0'})
+})


### PR DESCRIPTION
What I wanted to do was to have a handler (along with description, args etc.) directly under a namespace. These are the two issues that were found and fixed:
1. In the namespace handler there was always one arg missing from the left. Now all args are being passed appropriately.
2. The help function threw an exception when trying to deal with a namespace that is also a command. Now it doesn't, and the command is being documented as expected.
