### PR TITLE
Fill missing args with undefined instead of null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "findhelp",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "A simple and hackable lib to help create modular command line programs.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/finder.js
+++ b/src/finder.js
@@ -102,7 +102,7 @@ export function find (node, argv) {
 
   const filledArgs = givenArgs.slice(0, argsNumber)
   if (givenArgsNumber < argsNumber) {
-    filledArgs.push(...new Array(argsNumber - givenArgsNumber).fill(null))
+    filledArgs.push(...new Array(argsNumber - givenArgsNumber).fill(undefined))
   }
 
   return {

--- a/src/finder.test.js
+++ b/src/finder.test.js
@@ -30,7 +30,7 @@ const cases = [
   {
     argv: ['list'],
     command: tree.list,
-    args: [null, {
+    args: [undefined, {
       a: false,
       all: false,
     }],
@@ -38,7 +38,7 @@ const cases = [
   {
     argv: ['list', '-a'],
     command: tree.list,
-    args: [null, {
+    args: [undefined, {
       a: true,
       all: false,
     }],
@@ -91,7 +91,7 @@ const cases = [
   {
     argv: ['settings', 'cool-app'],
     command: tree.settings,
-    args: ['cool-app', null, {}],
+    args: ['cool-app', undefined, {}],
   },
   {
     argv: ['settings', 'cool-app', 'someField'],


### PR DESCRIPTION
This PR proposes that we fill missing arguments with `undefined` instead of `null`. In this way, typescript can assign default values for missing arguments.

### Example:
In the following code:
```
const f = (arg = 'something') => { return arg }
```

- If `arg` is `null`, the function will return `null`.
- If `arg` is `undefined`, the function will return `'something'`.

With this change, the handlers called by findhelp's run will use their default arguments (`'something'` in the above code) if an optional argument has not been suplied in the command line.