### PR TITLE
Make 'minimist' a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chalk": "^2.4.1",
     "es6-error": "^4.1.1",
     "pad": "^2.2.1",
+    "minimist": "^1.2.0",
     "ramda": "^0.25.0"
   },
   "devDependencies": {
@@ -55,7 +56,6 @@
     "babel-register": "^6.9.0",
     "coveralls": "^3.0.2",
     "eslint": "^5.6.0",
-    "minimist": "^1.2.0",
     "nyc": "^13.0.1"
   },
   "ava": {


### PR DESCRIPTION
`minimist` is used by the shipped version of `findhelp`, but it was listed as a `devDependency`, which meant packages that depended on it would need to have `minimist` installed themselves.

This should also eliminate the need for 

```yml
packageExtensions:
  findhelp@*:
    dependencies:
      minimist: "*"
```

in the `.yarnrc.yml` file in [`micro`](https://github.com/vtex/micro/blob/master/.yarnrc.yml#L26), making the setup for new projects closer to frictionless 😃 . 

To understand why this `packageExtensions` field was necessary in the first place, head over to the [docs](https://yarnpkg.com/configuration/yarnrc#packageExtensions).